### PR TITLE
Remove unnecessary steps from frontend yml

### DIFF
--- a/.github/workflows/azure-frontend-build-deploy.yml
+++ b/.github/workflows/azure-frontend-build-deploy.yml
@@ -23,19 +23,6 @@ jobs:
           submodules: true
           lfs: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '20'
-
-      - name: Install dependencies
-        run: npm ci
-        working-directory: ./frontend
-
-      - name: Build frontend
-        run: npm run build --if-present
-        working-directory: ./frontend
-
       - name: Install OIDC Client from Core Package
         run: npm install @actions/core@1.6.0 @actions/http-client
 
@@ -57,3 +44,4 @@ jobs:
           app_location: "./frontend"
           api_location: ""
           output_location: "build"
+          github_id_token: ${{ steps.idtoken.outputs.result }}


### PR DESCRIPTION
remove the setup nodejs, install dependencies and build frontend steps since azure can take care of that. Input expected github id token to azure deploy method