### PR TITLE
Fix infinite loop caused by unstable handleError reference

### DIFF
--- a/frontend/src/hooks/useErrorHandler.js
+++ b/frontend/src/hooks/useErrorHandler.js
@@ -1,5 +1,7 @@
+import { useCallback } from "react"
+
 export const useErrorHandler = () => {
-    const handleError = (error) => {
+    const handleError = useCallback((error) => {
         if (!error.response) {
             alert("Network error or server not responding. Please try again.");
             return;
@@ -10,7 +12,7 @@ export const useErrorHandler = () => {
         const details = data?.validationErrors || null;
 
         return { message, details, status };
-    };
+    }, []);
 
     return handleError;
 }


### PR DESCRIPTION
Infinite loop was caused by the reference to handleError which was creating a new instance every render so this triggered a new instance of FetchTasks and FetchUsers which triggered useEffect and it started an infinite loop. Fix this by wrapping handleError in useCallback()